### PR TITLE
Fix incorrect var name for swap file size.

### DIFF
--- a/vars.yml.dist
+++ b/vars.yml.dist
@@ -13,7 +13,7 @@ do_image: 9801950 # Ubuntu 14.04 x64
 
 # Swap settings
 swap_file_path: /mnt/1GB.swap
-swap_file_size_kb: 1048576
+swap_file_size_mb: 1024
 
 # System user to create
 ssh_user: "{{ lookup('env', 'USERNAME') }}"


### PR DESCRIPTION
Var name didn't match use in tasks/swap.yml leading to an error when running the launch playbook. This change fixes that.
